### PR TITLE
Exprの等価性の実装 (__eq__と__hash__の実装)

### DIFF
--- a/AlphaStrictPrf/strict_prf.py
+++ b/AlphaStrictPrf/strict_prf.py
@@ -2,6 +2,24 @@ from typing import List
 
 
 class Expr:
+    def __eq__(self, other):
+        """Expr型のクラスの等価性を確認する"""
+        if type(self) is not type(other):
+            return False
+        return self._eq_impl(other)
+
+    def _eq_impl(self, other):
+        """派生クラスで実装する等価性の比較"""
+        raise NotImplementedError()
+
+    def __hash__(self):
+        """Expr型のクラスのハッシュ値を計算する"""
+        return hash(self._hash_impl())
+
+    def _hash_impl(self):
+        """派生クラスで実装するハッシュ値の計算"""
+        raise NotImplementedError()
+
     def evaluate(self, *args: int) -> int:
         """PRFを自然数関数に変換して入力に対する値を評価する"""
         raise NotImplementedError()
@@ -42,6 +60,12 @@ class Z(Expr):
     def __init__(self, *args: any):
         self.num_args = len(args)
 
+    def _eq_impl(self, other):
+        return True  # Z() は常に等しい
+
+    def _hash_impl(self):
+        return hash("Z")  # 固定のハッシュ値を返す
+
     def evaluate(self, *args: int) -> int:
         return 0
 
@@ -65,6 +89,12 @@ class Z(Expr):
 class S(Expr):
     def __init__(self, *args):
         assert len(args) == 0, "The number of args of S should be 0."
+
+    def _eq_impl(self, other):
+        return True  # S() も常に等しい
+
+    def _hash_impl(self):
+        return hash("S")
 
     def evaluate(self, arg: int) -> int:
         return arg + 1
@@ -91,6 +121,13 @@ class P(Expr):
         self.n = n
         self.i = i
         assert self.i <= self.n, "Error: P should be self.i <= self.n"
+
+    def _eq_impl(self, other):
+        # n と i が同じなら等しい
+        return self.n == other.n and self.i == other.i
+
+    def _hash_impl(self):
+        return hash((self.n, self.i))
 
     def evaluate(self, *args: int) -> int:
         assert (
@@ -119,6 +156,13 @@ class C(Expr):
     def __init__(self, func: Expr, *args: Expr):
         self.func = func
         self.args = args
+
+    def _eq_impl(self, other):
+        # func と args の全てが同じなら等しい
+        return self.func == other.func and self.args == other.args
+
+    def _hash_impl(self):
+        return hash((self.func, tuple(self.args)))
 
     def evaluate(self, *args: int) -> int:
         results_args: List[int] = [arg.evaluate(*args) for arg in self.args]
@@ -178,6 +222,13 @@ class R(Expr):
     def __init__(self, base: Expr, step: Expr):
         self.base = base
         self.step = step
+
+    def _eq_impl(self, other):
+        # base と step が同じなら等しい
+        return self.base == other.base and self.step == other.step
+
+    def _hash_impl(self):
+        return hash((self.base, self.step))
 
     def evaluate(self, n: int, *args: int) -> int:
         if n == 0:

--- a/tests/AlphaStrictPrf/test_strict_prf.py
+++ b/tests/AlphaStrictPrf/test_strict_prf.py
@@ -160,3 +160,7 @@ def test_eq():
     expr1 = R(S(), C(P(3, 1), S(), S()))
     expr2 = R(S(), C(P(3, 1), Z(), Z()))
     assert expr1 is not expr2, "Error: Expr.__eq__()"
+
+    expr_set1 = {C(S(), Z()), R(S(), C(P(3, 1), S(), S())), Z()}
+    expr_set2 = {R(S(), C(P(3, 1), S(), S())), Z(), C(S(), Z())}
+    assert expr_set1 == expr_set2, "Error: Expr set equality"

--- a/tests/AlphaStrictPrf/test_strict_prf.py
+++ b/tests/AlphaStrictPrf/test_strict_prf.py
@@ -150,7 +150,13 @@ def test_eq():
     expr1 = C(S(), Z())
     expr2 = C(S(), Z())
     assert expr1 == expr2, "Error: Expr.__eq__()"
+    assert hash(expr1) == hash(expr2), "Error: Expr.__hash__()"
 
-    expr1 = R(S(), C(P(3, 1), Z(), S()))
-    expr2 = R(S(), C(P(3, 1), Z(), S()))
+    expr1 = R(S(), C(P(3, 1), S(), S()))
+    expr2 = R(S(), C(P(3, 1), S(), S()))
     assert expr1 == expr2, "Error: Expr.__eq__()"
+    assert hash(expr1) == hash(expr2), "Error: Expr.__hash__()"
+
+    expr1 = R(S(), C(P(3, 1), S(), S()))
+    expr2 = R(S(), C(P(3, 1), Z(), Z()))
+    assert expr1 is not expr2, "Error: Expr.__eq__()"

--- a/tests/AlphaStrictPrf/test_strict_prf.py
+++ b/tests/AlphaStrictPrf/test_strict_prf.py
@@ -144,3 +144,13 @@ def test_R():
     assert (
         inner_invalid2.validate_semantic() is False
     ), "Error: validate_semantic() works incorrectly"
+
+
+def test_eq():
+    expr1 = C(S(), Z())
+    expr2 = C(S(), Z())
+    assert expr1 == expr2, "Error: Expr.__eq__()"
+
+    expr1 = R(S(), C(P(3, 1), Z(), S()))
+    expr2 = R(S(), C(P(3, 1), Z(), S()))
+    assert expr1 == expr2, "Error: Expr.__eq__()"


### PR DESCRIPTION
# 概要
Exprに__eq__と__hash__メソッドを付けた。

# 背景
- #35

# 変更点
- Expr.__eq__()
- Expr.__hash__()
- Expr._eq_impl()
- Expr._hash_impl()