### PR TITLE
step_human_readable()のバグ修正

### DIFF
--- a/AlphaStrictPrf/strict_prf_game.py
+++ b/AlphaStrictPrf/strict_prf_game.py
@@ -158,46 +158,51 @@ class StrictPrfGame:
         exp = action.expr
         if pos not in self.available_positions():
             return (
-                str(self.current_expr),
+                self.current_expr,
                 0 + length_score,
                 False,
                 truncated,
+                self._get_info(),
             )
 
         new_expr: Expr = self.current_expr.change(pos, exp)
-        if not new_expr.validate_semantic() or new_expr.arity() != 1:
+        if not new_expr.validate_semantic():
             return (
-                str(self.current_expr),
+                self.current_expr,
                 0.1 + length_score,
                 False,
                 truncated,
+                self._get_info(),
             )
         if new_expr.arity() != 1:
             return (
-                str(self.current_expr),
+                self.current_expr,
                 0.2 + length_score,
                 False,
                 truncated,
+                self._get_info(),
             )
+        self.current_expr = new_expr  # change expression
         matching_elements = sum(
             1
             for t, e in zip(self.output_sequence, self.input_sequence)
-            if t == self.current_expr.evaluate(e)
+            if t == new_expr.evaluate(e)
         )
         if matching_elements == len(self.input_sequence):
             return (
-                str(new_expr),
+                new_expr,
                 1 + length_score,
                 True,
                 truncated,
+                self._get_info(),
             )
 
         self.step_count += 1
         correctness_score = 0.3 * matching_elements / len(self.input_sequence)
         return (
-            str(new_expr),
+            new_expr,
             0.3 + correctness_score + length_score,
             False,
             truncated,
-            self.get_info(),
+            self._get_info(),
         )

--- a/AlphaStrictPrf/strict_prf_game.py
+++ b/AlphaStrictPrf/strict_prf_game.py
@@ -182,7 +182,11 @@ class StrictPrfGame:
                 truncated,
                 self._get_info(),
             )
-        self.current_expr = new_expr  # change expression
+
+        # new expression is accepted as next expression
+        self.current_expr = new_expr
+        length_score = 0.9 ** len(str(self.current_expr))
+
         matching_elements = sum(
             1
             for t, e in zip(self.output_sequence, self.input_sequence)

--- a/tests/AlphaStrictPrf/test_strict_prf_game.py
+++ b/tests/AlphaStrictPrf/test_strict_prf_game.py
@@ -111,56 +111,60 @@ def test_step_human_readable():
         2, 2, 2, 100, input, output, n_obs=100, init_expr=C(P(1, 1), S())
     )
     game1.reset()
-    action1 = Action([1], Z())
+    action1 = Action(deque([1]), Z())
     ret = game1.step_human_readable(action1)
-    match ret:
-        case ("C(P(1, 1), S()", _, False, False, _):
+    ret_str = (str(ret[0]), *ret[1:])
+    match ret_str:
+        case ("C(P(1, 1), S())", _, False, False, _):
             pass
         case _:
-            AssertionError("Error: StrictPrfGame.step_human_readable()")
+            pytest.fail("Error: StrictPrfGame.step_human_readable()")
 
     # When generating arity != 1
     input = [1, 2, 3]
     output = [1, 2, 3]
     game2 = StrictPrfGame(2, 2, 2, 100, input, output, n_obs=100)
     game2.reset()
-    action1 = Action([], P(2, 1))
+    action1 = Action(deque([]), P(2, 1))
 
     ret = game2.step_human_readable(action1)
-    match ret:
-        case ("P(1, 1)", _, False, False, _):
+    ret_str = (str(ret[0]), *ret[1:])
+    match ret_str:
+        case ("Z()", _, False, False, _):
             pass
         case _:
-            AssertionError("Error: StrictPrfGame.step_human_readable()")
+            pytest.fail("Error: StrictPrfGame.step_human_readable()")
 
     # When agent steped too much
     input = [1, 2, 3]
     output = [4, 5, 6]
     game3 = StrictPrfGame(2, 2, 2, 3, input, output, n_obs=10)
     game3.reset()
-    action1 = Action([], P(2, 1))
-    action2 = Action([], Z())
-    action3 = Action([], P(1, 1))
+    action1 = Action(deque([]), P(2, 1))
+    action2 = Action(deque([]), Z())
+    action3 = Action(deque([]), P(1, 1))
     game3.step_human_readable(action1)
     game3.step_human_readable(action2)
     ret = game3.step_human_readable(action3)
+    ret_str = (str(ret[0]), *ret[1:])
 
-    match ret:
+    match ret_str:
         case ("P(1, 1)", _, False, True, _):
             pass
         case _:
-            AssertionError("Error: StrictPrfGame.step_human_readable()")
+            pytest.fail("Error: StrictPrfGame.step_human_readable()")
 
     # When generate correct answer
     input = [1, 2, 3]
     output = [1, 2, 3]
     game4 = StrictPrfGame(2, 2, 2, 100, input, output, n_obs=100)
     game4.reset()
-    action1 = Action([], P(1, 1))
+    action1 = Action(deque([]), P(1, 1))
 
     ret = game4.step_human_readable(action1)
-    match ret:
+    ret_str = (str(ret[0]), *ret[1:])
+    match ret_str:
         case ("P(1, 1)", _, True, False, _):
             pass
         case _:
-            AssertionError("Error: StrictPrfGame.step_human_readable()")
+            pytest.fail("Error: StrictPrfGame.step_human_readable()")


### PR DESCRIPTION
# 背景

test_step_human_readable()のAssertionErrorはpytestによって適切に処理されないので消した。

# 変更箇所
- step_human_readable()の返り値タプルの0番目をstrからExprに変更
- test_step_human_readable()のAssertionErrorを削除したことにより生じる様々なエラーのbugfix
- Actionとしてdeque()を与えるように変更