### PR TITLE
Exprのchange関数を非破壊のコピーにする

### DIFF
--- a/AlphaStrictPrf/strict_prf.py
+++ b/AlphaStrictPrf/strict_prf.py
@@ -293,10 +293,12 @@ class C(Expr):
 
         arg_id = pos.popleft()
         if arg_id == 1:
-            return C(self.func.change(pos, expr), *self.args)
+            copy_args = (arg.copy() for arg in self.args)
+            return C(self.func.change(pos, expr), *copy_args)
         elif arg_id >= 2:
-            self.args[arg_id - 2] = self.args[arg_id - 2].change(pos, expr)
-            return C(self.func, *self.args)
+            copy_args = [arg.copy() for arg in self.args]
+            copy_args[arg_id - 2] = copy_args[arg_id - 2].change(pos, expr)
+            return C(self.func.copy(), *copy_args)
         else:
             raise ValueError(
                 "Error: pos arg of C.change() is invalid. Positive int is needed."
@@ -383,9 +385,9 @@ class R(Expr):
 
         arg_id = pos.popleft()
         if arg_id == 1:
-            return self.base.change(pos, expr)
+            return R(self.base.change(pos, expr), self.step.copy())
         elif arg_id == 2:
-            return self.step.change(pos, expr)
+            return R(self.base.copy(), self.step.change(pos, expr))
         else:
             raise ValueError(
                 "Error: invaid pos argument (not 1 or 2) at R.change()"

--- a/tests/AlphaStrictPrf/test_strict_prf.py
+++ b/tests/AlphaStrictPrf/test_strict_prf.py
@@ -202,6 +202,7 @@ def test_change():
     for pos in expr.positions():
         expr_copy.change(pos, Z())
         assert expr_copy == expr, "Error: Expr.change()"
+        assert id(expr_copy) != id(expr), "Error: Expr.change()"
 
 
 def test_copy():

--- a/tests/AlphaStrictPrf/test_strict_prf.py
+++ b/tests/AlphaStrictPrf/test_strict_prf.py
@@ -194,9 +194,14 @@ def test_str():
 def test_change():
     expr = C(R(Z(), P(2, 1)), C(P(1, 1), S()))
     pos = deque([2, 1])
-    expr = expr.change(pos, R(Z(), P(2, 1)))
+    new_expr = expr.change(pos, R(Z(), P(2, 1)))
     expected_expr = C(R(Z(), P(2, 1)), C(R(Z(), P(2, 1)), S()))
-    assert expr == expected_expr, "Error: Expr.change()"
+    assert new_expr == expected_expr, "Error: Expr.change()"
+    # check non-destructive
+    expr_copy = expr.copy()
+    for pos in expr.positions():
+        expr_copy.change(pos, Z())
+        assert expr_copy == expr, "Error: Expr.change()"
 
 
 def test_copy():


### PR DESCRIPTION
# 概要
#53 の途中ででたバグを解決するべく導入した

# 変更点
- Expr.change()を非破壊に
- R.change()の致命的なエラーを修正