### PR TITLE
Expr.copy()の実装

### DIFF
--- a/AlphaStrictPrf/strict_prf.py
+++ b/AlphaStrictPrf/strict_prf.py
@@ -303,7 +303,8 @@ class C(Expr):
             )
 
     def copy(self):
-        return C(self.func, *self.args)
+        copy_args = (arg.copy() for arg in self.args)
+        return C(self.func.copy(), *copy_args)
 
 
 class R(Expr):
@@ -391,4 +392,4 @@ class R(Expr):
             )
 
     def copy(self):
-        return R(self.base, self.step)
+        return R(self.base.copy(), self.step.copy())

--- a/AlphaStrictPrf/strict_prf.py
+++ b/AlphaStrictPrf/strict_prf.py
@@ -76,6 +76,12 @@ class Expr:
         - `expr` ("Expr"): 新しい式。指定された場所に置き換える新しいサブ式。
         """
 
+    def copy(self) -> "Expr":
+        """
+        属性が全く等しいコピーを作成する
+        """
+        raise NotImplementedError()
+
 
 class Z(Expr):
     def __init__(self, *args: any):
@@ -113,6 +119,9 @@ class Z(Expr):
         assert pos == Deque([]), "Error: invalid pos arg in Z.change()."
         return expr
 
+    def copy(self):
+        return Z()
+
 
 class S(Expr):
     def __init__(self, *args):
@@ -149,6 +158,9 @@ class S(Expr):
     def change(self, pos: Deque[int], expr: "Expr") -> None:
         assert pos == Deque([]), "Error: invalid pos arg in S.change()."
         return expr
+
+    def copy(self):
+        return S()
 
 
 class P(Expr):
@@ -192,6 +204,9 @@ class P(Expr):
     def change(self, pos: Deque[int], expr: "Expr") -> None:
         assert pos == Deque([]), "Error: invalid pos arg in P.change()."
         return expr
+
+    def copy(self):
+        return P(self.n, self.i)
 
 
 class C(Expr):
@@ -287,6 +302,9 @@ class C(Expr):
                 "Error: pos arg of C.change() is invalid. Positive int is needed."
             )
 
+    def copy(self):
+        return C(self.func, *self.args)
+
 
 class R(Expr):
     def __init__(self, base: Expr, step: Expr):
@@ -361,6 +379,7 @@ class R(Expr):
     def change(self, pos: Deque[int], expr: "Expr") -> None:
         if pos == Deque([]):
             return expr
+
         arg_id = pos.popleft()
         if arg_id == 1:
             return self.base.change(pos, expr)
@@ -370,3 +389,6 @@ class R(Expr):
             raise ValueError(
                 "Error: invaid pos argument (not 1 or 2) at R.change()"
             )
+
+    def copy(self):
+        return R(self.base, self.step)

--- a/tests/AlphaStrictPrf/test_strict_prf.py
+++ b/tests/AlphaStrictPrf/test_strict_prf.py
@@ -197,3 +197,13 @@ def test_change():
     expr = expr.change(pos, R(Z(), P(2, 1)))
     expected_expr = C(R(Z(), P(2, 1)), C(R(Z(), P(2, 1)), S()))
     assert expr == expected_expr, "Error: Expr.change()"
+
+
+def test_copy():
+    assert Z().copy() == Z(), "Error: Z().copy"
+    assert S().copy() == S(), "Error: S().copy"
+    assert P(3, 1).copy() == P(3, 1), "Error: P(1, 2).copy"
+    assert C(S(), Z()).copy() == C(S(), Z()), "Error: C(S(), Z()).copy"
+    assert R(C(1, 1), P(3, 1)).copy() == R(
+        C(1, 1), P(3, 1)
+    ), "Error: R(C(1, 1), P(3, 1).copy"

--- a/tests/AlphaStrictPrf/test_strict_prf.py
+++ b/tests/AlphaStrictPrf/test_strict_prf.py
@@ -204,6 +204,6 @@ def test_copy():
     assert S().copy() == S(), "Error: S().copy"
     assert P(3, 1).copy() == P(3, 1), "Error: P(1, 2).copy"
     assert C(S(), Z()).copy() == C(S(), Z()), "Error: C(S(), Z()).copy"
-    assert R(C(1, 1), P(3, 1)).copy() == R(
-        C(1, 1), P(3, 1)
+    assert R(P(1, 1), P(3, 1)).copy() == R(
+        P(1, 1), P(3, 1)
     ), "Error: R(C(1, 1), P(3, 1).copy"


### PR DESCRIPTION
# 背景
#54 のためにコピー関数があったほうが良さそうだった

# 変更点
- Expr.copy()の実装
- テストコードの記述(idが異なることまでは確かめていない)