### PR TITLE
vscodeのpytest中にlogging.debugを使えるように

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,5 @@ indent-style = "space"
 norecursedirs = ["alpha-zero-general"]
 pythonpath = "."
 testpaths = ["tests",]
+log_cli = true
+log_level = "DEBUG"


### PR DESCRIPTION
# 変更点
- pyproject.tomlに標準出力のターミナル表示とlog_level=DEBUGを設定