### PR TITLE
bugfix step_human_readable内におけるself.current_expr.change()の場所変更

### DIFF
--- a/AlphaStrictPrf/strict_prf_game.py
+++ b/AlphaStrictPrf/strict_prf_game.py
@@ -167,9 +167,6 @@ class StrictPrfGame:
         pos = action.position
         exp = action.expr
 
-        # new expression is accepted as next expression
-        self.current_expr: Expr = self.current_expr.change(pos, exp)
-
         # position is invalid
         if pos not in self.available_positions():
             return (
@@ -179,6 +176,9 @@ class StrictPrfGame:
                 truncated,
                 self._get_info(),
             )
+
+        # new expression is accepted as next expression
+        self.current_expr: Expr = self.current_expr.change(pos, exp)
 
         # Next expression is invalid semantically
         if not self.current_expr.validate_semantic():

--- a/AlphaStrictPrf/strict_prf_game.py
+++ b/AlphaStrictPrf/strict_prf_game.py
@@ -164,7 +164,7 @@ class StrictPrfGame:
     ) -> tuple[str, float, bool, bool, dict[str, Any]]:
         logging.debug("Starting step_human_readable method")
         self.step_count += 1
-        length_score = 0.9 ** len(str(self.current_expr))
+        length_score = 0.9 ** len(str(self.current_expr))  # in 0 < x < 1
         truncated = self.step_count >= self.max_steps
         pos = action.position
         exp = action.expr
@@ -182,6 +182,7 @@ class StrictPrfGame:
 
         # new expression is accepted as next expression
         self.current_expr: Expr = self.current_expr.change(pos, exp)
+        length_score = 0.9 ** len(str(self.current_expr))  # in 0 < x < 1
 
         # Next expression is invalid semantically
         if not self.current_expr.validate_semantic():
@@ -221,6 +222,7 @@ class StrictPrfGame:
             )
 
         self.step_count += 1
+        # 0 to 0.3
         correctness_score = 0.3 * matching_elements / len(self.input_sequence)
         logging.debug("Correctness score: {correctness_score}")
         return (

--- a/tests/AlphaStrictPrf/test_strict_prf_game.py
+++ b/tests/AlphaStrictPrf/test_strict_prf_game.py
@@ -151,7 +151,7 @@ class TestStepHumanReadable:
             P(2, 1), S()
         )  # Current expression changed
         assert result[:4] == (
-            game.current_expr.change(1, action.expr),  # New expression
+            C(P(2, 1), S()),  # New expression
             0.1 + 0.9 ** len(str(game.current_expr)),  # Expected score
             False,  # Done flag
             False,  # Truncated flag (step count < max_steps)
@@ -234,7 +234,7 @@ class TestStepHumanReadable:
         expected_score += 0.9 ** len(str(game.current_expr))  # Add length score
 
         assert result[:4] == (
-            game.current_expr.change(1, action.expr),  # New expression
+            C(S(), C(S(), Z())),  # New expression
             expected_score,  # Partial correctness score
             False,  # Done flag
             False,  # Truncated flag (step count < max_steps)


### PR DESCRIPTION
# 概要
ゲームないで現在の式が更新されるのは、渡されたpositionが妥当なものであった時だが、そうでなくても現在の式が更新されることになっていた。

# 変更点
- self.current_expr.change() を行う点
- length_scoreを計算する箇所
- TestStepHumanReadableのミス修正 (PRを分けるのが面倒だった)