### PR TITLE
S.evaluate()とP.evaluate() に assert 追加

### DIFF
--- a/AlphaStrictPrf/strict_prf.py
+++ b/AlphaStrictPrf/strict_prf.py
@@ -133,8 +133,11 @@ class S(Expr):
     def _hash_impl(self):
         return hash("S")
 
-    def evaluate(self, arg: int) -> int:
-        return arg + 1
+    def evaluate(self, *args: int) -> int:
+        assert (
+            len(args) == 1
+        ), "Error: the number of args of S.evaluate() should be 1."
+        return args[0] + 1
 
     def tree_string(self, indent: int = 0) -> None:
         return " " * indent + "S"
@@ -195,7 +198,8 @@ class P(Expr):
         assert self.validate_semantic(), "Error: Invalid semantically"
         return self.n
 
-    def validate_semantic(self):
+    def validate_semantic(self, *args):
+        assert len(args) == self.n, "Error: P should have args of self.n."
         return True
 
     def positions(self):

--- a/tests/AlphaStrictPrf/test_strict_prf.py
+++ b/tests/AlphaStrictPrf/test_strict_prf.py
@@ -1,6 +1,8 @@
 import logging
 from collections import deque
 
+import pytest
+
 from AlphaStrictPrf.strict_prf import C, P, R, S, Z
 
 logging.basicConfig(level=logging.DEBUG)
@@ -53,6 +55,20 @@ def test_S():
     assert str(s_func) == "S()", "Error: S.__str__() wrongly."
     assert s_func.tree_string() == "S", "Error: S tree is wrong."
     assert s_func.complexity() == 1.0, "Error: Complesity of S is wrong"
+
+
+def test_invalid_R_evaluate():
+    rss_invalid_arity = R(S(), S())
+    logging.debug("Test Sample: R(S(), S())")
+    with pytest.raises(AssertionError):
+        rss_invalid_arity.evaluate(1)
+
+
+def test_invalid_P_evaluate():
+    p_func = P(3, 2)
+    logging.debug("P(3, 2)")
+    with pytest.raises(AssertionError):
+        p_func.evaluate(10, 20)
 
 
 def test_P():


### PR DESCRIPTION
# 概要
式が意味論的に正しいが与えられた自然数引数の数がarityとあっていないときにエラーを出す必要がある。そこでこれを実装した

# 変更点
- S.evaluate()にassert追加
- P.evaluate()にassert追加
- test_invalid_P_evaluate()をついか (間違った自然数の引数をあたえる)
- test_invalid_R_evaluate()をついか (間違った自然数の引数をあたえる)