### PR TITLE
ActType.sample() の生成範囲修正

### DIFF
--- a/AlphaStrictPrf/strict_prf_game.py
+++ b/AlphaStrictPrf/strict_prf_game.py
@@ -14,7 +14,7 @@ class ActType:
         self.n_post_expr = 3 + int(1 / 2 * p * (p + 1)) + c
 
     def sample(self):
-        return random.randint(0, self.n)
+        return random.randint(0, self.n - 1)
 
 
 class StrictPrfGame:


### PR DESCRIPTION
# 目的
#61 におけるバグ修正

# 背景
#61 のバグでActType.sample()のrandom.randint()の引数が1ずれていることが原因だとわかった