### PR TITLE
R.evaluate()にassert追加

### DIFF
--- a/AlphaStrictPrf/strict_prf.py
+++ b/AlphaStrictPrf/strict_prf.py
@@ -352,13 +352,18 @@ class R(Expr):
     def _hash_impl(self):
         return hash((self.base, self.step))
 
-    def evaluate(self, n: int, *args: int) -> int:
+    def evaluate(self, *args: int) -> int:
+        assert (
+            len(args) >= 1
+        ), "Error: the number of args of R.evaluate() should be >= 1."
+        n = args[0]
+        post_args = args[1:]
         if n == 0:
-            return self.base.evaluate(*args)
+            return self.base.evaluate(*post_args)
         else:
             step_back = R(self.base, self.step)
             return self.step.evaluate(
-                n - 1, step_back.evaluate(n - 1, *args), *args
+                n - 1, step_back.evaluate(n - 1, *post_args), *post_args
             )
 
     def tree_string(self, indent: int = 0) -> str:

--- a/AlphaStrictPrf/strict_prf_game.py
+++ b/AlphaStrictPrf/strict_prf_game.py
@@ -90,6 +90,12 @@ class StrictPrfGame:
         print(f"Current Expression:\n{str(self.current_expr)}")
 
     def current_output(self):
+        """
+        Evaluates the output of the current expression on the input sequence.
+        Returns:
+            output (List[int]): The output of the current expression on the input sequence.
+                when the expression is invalid, returns [-1, -1, ...]
+        """
         try:
             output = [
                 self.current_expr.evaluate(i) for i in self.input_sequence

--- a/tests/AlphaStrictPrf/test_strict_prf_game.py
+++ b/tests/AlphaStrictPrf/test_strict_prf_game.py
@@ -426,3 +426,25 @@ def test_step_flow():
     assert (
         truncated == False
     ), "Error: return value truncated of StrictPrfGame.step()"
+
+
+def test_current_output():
+    game = StrictPrfGame(
+        max_p_arity=3,
+        expr_depth=4,
+        max_c_args=2,
+        max_steps=10,
+        input_sequence=[1, 2, 3, 4, 5, 6],
+        output_sequence=[4, 5, 6, 7, 8, 9],
+        n_obs=50,
+        init_expr=R(R(Z(), Z()), S()),
+    )
+    game.reset()
+    assert game.current_output() == [
+        -1,
+        -1,
+        -1,
+        -1,
+        -1,
+        -1,
+    ], "Error: current_output()"


### PR DESCRIPTION
# 概要 
current_outputのtry exceptでevaluateのエラーをキャッチでいない現象が起きた。
原因はR.evaluate(n, *args)という引数の取り方ではevaluate()が引数なしで呼ばれるとTypeErrorが起きcurrent_outputのcatchでとらえられないからである(∵AssertionErrorではないから)