### PR TITLE
tempディレクトリを.gitignoreに入れ、メモ代わりに用いる

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+/temp


### PR DESCRIPTION
# 目的
tempディクトリを.gitignoreに入れ常に無視できるようにする。これによりtempディレクトリに自分のメモを入れて置けるようになる。