### PR TITLE
R.evaluate()における末尾再帰のfor文展開

### DIFF
--- a/AlphaStrictPrf/generate_output_by_size.py
+++ b/AlphaStrictPrf/generate_output_by_size.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from itertools import product
 from typing import Any, Callable
 
@@ -341,14 +342,19 @@ def generate_output_by_size(
     - max_c_args (int): Maximum the number of arguments of C.
     - eq_domain (List[int]): List of inputs to defining semantic equivalence of Exprs.
     """
+    start_time = time.time()
     visited: list[set[bytes]] = [set() for _ in range(size + 1)]
-    return _generate_output_by_size(
+    ret = _generate_output_by_size(
         size,
         max_p_arity,
         max_c_args,
         eq_domain,
         visited,
     )
+    end_time = time.time()
+    duration = end_time - start_time
+    logging.info(f"Duration: {duration} sec.")
+    return ret
 
 
 def generate_expression_table(

--- a/AlphaStrictPrf/strict_prf.py
+++ b/AlphaStrictPrf/strict_prf.py
@@ -1,6 +1,8 @@
 from collections import deque
 from typing import Any, Deque, List
 
+OPTIMIZE_TAIL_RECURSION = True
+
 
 class InputSizeError(Exception):
     "the number of inputs is invalid for the arity of then function"
@@ -413,13 +415,19 @@ class R(Expr):
         try:
             if n == 0:
                 return self.base.evaluate(*post_args)
+            if OPTIMIZE_TAIL_RECURSION:
+                rec_ans = self.base.evaluate(*post_args)
+                for i in range(0, n):
+                    rec_ans = self.step.evaluate(i, rec_ans, *post_args)
+                return rec_ans
+
             step_back = R(self.base, self.step)
             step_back_ans = step_back.evaluate(n - 1, *post_args)
             ret = self.step.evaluate(n - 1, step_back_ans, *post_args)
+            return ret
         except InputSizeError as e:
             raise InputSizeError(f"""{e}
                                  {str(self)} got invalid input size {len(args)}.""")
-        return ret
 
     def tree_string(self, indent: int = 0) -> str:
         buffer = " " * indent + "R\n"


### PR DESCRIPTION
# 概要
#106 に習う。
R.evaluate()は末尾再帰を含むのでOPTIMIZE_TAIL_RECURSIONパラメータでfor文に展開して計算するかを選べるようにした。

# 変更点
- OPTIMIZE_TAIL_RECURSIONパラメータの追加
- R.evaluate()に再帰呼び出しをしない処理を追加。
- generate_output_by_size()に時間計測を追加

# 補足
- gameや最大深さの探索テストにおいてエラーが出ていることに気が付いたが、いつからでいているのかわからないことと、エラーの内容が小さそうなので、無視した。
- 末尾再帰の除去でが2/3の速度になった。うれしい。