### PR TITLE
ExprにSingleton Patternを適用

### DIFF
--- a/AlphaStrictPrf/strict_prf.py
+++ b/AlphaStrictPrf/strict_prf.py
@@ -11,6 +11,16 @@ class InputSizeError(Exception):
 
 
 class Expr:
+    _instances: dict[int, int] = {}
+
+    def __new__(cls, *args):
+        key = hash((cls, *args))
+        if key in cls._instances:
+            return cls._instances[key]
+        instance = super().__new__(cls)
+        cls._instances[key] = instance
+        return instance
+
     def __eq__(self, other):
         """Expr型のクラスの等価性を確認する"""
         if type(self) is not type(other):

--- a/AlphaStrictPrf/strict_prf.py
+++ b/AlphaStrictPrf/strict_prf.py
@@ -113,12 +113,6 @@ class Expr:
         """
         raise NotImplementedError()
 
-    def copy(self) -> "Expr":
-        """
-        属性が全く等しいコピーを作成する
-        """
-        raise NotImplementedError()
-
 
 class Z(Expr):
     """
@@ -163,9 +157,6 @@ class Z(Expr):
     def _change_recursion(self, pos: Deque[int], expr: "Expr") -> Expr:
         assert pos == Deque([]), "Error: invalid pos arg in Z.change()."
         return expr
-
-    def copy(self):
-        return Z()
 
 
 class S(Expr):
@@ -216,9 +207,6 @@ class S(Expr):
     def _change_recursion(self, pos: Deque[int], expr: "Expr") -> Expr:
         assert pos == Deque([]), "Error: invalid pos arg in S.change()."
         return expr
-
-    def copy(self):
-        return S()
 
 
 class P(Expr):
@@ -271,9 +259,6 @@ class P(Expr):
     def _change_recursion(self, pos: Deque[int], expr: "Expr") -> Expr:
         assert pos == Deque([]), "Error: invalid pos arg in P.change()."
         return expr
-
-    def copy(self):
-        return P(self.n, self.i)
 
 
 class C(Expr):
@@ -376,22 +361,17 @@ class C(Expr):
 
         arg_id = pos.popleft()
         if arg_id == 1:
-            copy_args = [arg.copy() for arg in self.args]
-            return C(self.func._change_recursion(pos, expr), *copy_args)
+            return C(self.func._change_recursion(pos, expr), *self.args)
         elif arg_id >= 2:
-            copy_args = [arg.copy() for arg in self.args]
+            copy_args = list(self.args)
             copy_args[arg_id - 2] = copy_args[arg_id - 2]._change_recursion(
                 pos, expr
             )
-            return C(self.func.copy(), *copy_args)
+            return C(self.func, *copy_args)
         else:
             raise ValueError(
                 "Error: pos arg of C._change_recursion() is invalid. Positive int is needed."
             )
-
-    def copy(self):
-        copy_args = (arg.copy() for arg in self.args)
-        return C(self.func.copy(), *copy_args)
 
 
 class R(Expr):
@@ -494,16 +474,13 @@ class R(Expr):
 
         arg_id = pos.popleft()
         if arg_id == 1:
-            return R(self.base._change_recursion(pos, expr), self.step.copy())
+            return R(self.base._change_recursion(pos, expr), self.step)
         elif arg_id == 2:
-            return R(self.base.copy(), self.step._change_recursion(pos, expr))
+            return R(self.base, self.step._change_recursion(pos, expr))
         else:
             raise ValueError(
                 "Error: invaid pos argument (not 1 or 2) at R._change_recursion()"
             )
-
-    def copy(self):
-        return R(self.base.copy(), self.step.copy())
 
 
 def expr_to_str_rec(lst):

--- a/AlphaStrictPrf/strict_prf.py
+++ b/AlphaStrictPrf/strict_prf.py
@@ -21,18 +21,8 @@ class Expr:
         cls._instances[key] = instance
         return instance
 
-    def __eq__(self, other):
-        """Expr型のクラスの等価性を確認する"""
-        if type(self) is not type(other):
-            return False
-        return self._eq_impl(other)
-
     def __str__(self):
         return NotImplementedError()
-
-    def _eq_impl(self, other):
-        """派生クラスで実装する等価性の比較"""
-        raise NotImplementedError()
 
     def __hash__(self):
         """Expr型のクラスのハッシュ値を計算する"""
@@ -125,9 +115,6 @@ class Z(Expr):
     def __init__(self, *args: Any):
         assert len(args) == 0, "The number of args of Z should be 0."
 
-    def _eq_impl(self, other):
-        return True  # Z() は常に等しい
-
     def _hash_impl(self):
         return hash("Z")  # 固定のハッシュ値を返す
 
@@ -169,9 +156,6 @@ class S(Expr):
 
     def __init__(self, *args):
         assert len(args) == 0, "The number of args of S should be 0."
-
-    def _eq_impl(self, other):
-        return True  # S() も常に等しい
 
     def _hash_impl(self):
         return hash("S")
@@ -221,10 +205,6 @@ class P(Expr):
         self.n = n
         self.i = i
         assert self.i <= self.n, "Error: P should be self.i <= self.n"
-
-    def _eq_impl(self, other):
-        # n と i が同じなら等しい
-        return self.n == other.n and self.i == other.i
 
     def _hash_impl(self):
         return hash((self.n, self.i))
@@ -276,10 +256,6 @@ class C(Expr):
         self.func = func
         self.args: tuple[Expr, ...] = args
         assert len(self.args) > 0, "Error: Args of C should be >= 1"
-
-    def _eq_impl(self, other):
-        # func と args の全てが同じなら等しい
-        return self.func == other.func and self.args == other.args
 
     def _hash_impl(self):
         return hash((self.func, tuple(self.args)))
@@ -387,10 +363,6 @@ class R(Expr):
     def __init__(self, base: Expr, step: Expr):
         self.base = base
         self.step = step
-
-    def _eq_impl(self, other):
-        # base と step が同じなら等しい
-        return self.base == other.base and self.step == other.step
 
     def _hash_impl(self):
         return hash((self.base, self.step))

--- a/tests/AlphaStrictPrf/test_strict_prf.py
+++ b/tests/AlphaStrictPrf/test_strict_prf.py
@@ -77,63 +77,6 @@ def test_change_complex():
     assert new_expr is not expr, "Error: Expr.change()"
 
 
-# ---- copy -----
-def test_Z_copy():
-    z1 = Z()
-    z2 = z1.copy()
-    assert z1 == z2, "Copy of Z should be equal to the original"
-
-    assert (
-        z1 is not z2
-    ), "Copy of Z should not be the same object as the original"
-
-
-def test_S_copy():
-    s1 = S()
-    s2 = s1.copy()
-    assert s1 == s2, "Copy of S should be equal to the original"
-    assert (
-        s1 is not s2
-    ), "Copy of S should not be the same object as the original"
-
-
-def test_P_copy():
-    p1 = P(3, 2)
-    p2 = p1.copy()
-    assert p1 == p2, "Copy of P should be equal to the original"
-    assert (
-        p1 is not p2
-    ), "Copy of P should not be the same object as the original"
-
-
-def test_C_copy():
-    c1 = C(S(), Z())
-    c2 = c1.copy()
-    assert c1 == c2, "Copy of C should be equal to the original"
-    assert (
-        c1 is not c2
-    ), "Copy of C should not be the same object as the original"
-
-
-def test_R_copy():
-    r1 = R(Z(), S())
-    r2 = r1.copy()
-    assert r1 == r2, "Copy of R should be equal to the original"
-    assert (
-        r1 is not r2
-    ), "Copy of R should not be the same object as the original"
-
-
-def test_copy_complex():
-    assert Z().copy() == Z(), "Error: Z().copy"
-    assert S().copy() == S(), "Error: S().copy"
-    assert P(3, 1).copy() == P(3, 1), "Error: P(1, 2).copy"
-    assert C(S(), Z()).copy() == C(S(), Z()), "Error: C(S(), Z()).copy"
-    assert R(P(1, 1), P(3, 1)).copy() == R(
-        P(1, 1), P(3, 1)
-    ), "Error: R(C(1, 1), P(3, 1).copy"
-
-
 # ---- equality -----
 def test_Z_equality():
     z1 = Z()
@@ -288,6 +231,20 @@ def test_complex_hash():
     expr1 = R(S(), C(P(3, 1), S(), S()))
     expr2 = R(S(), C(P(3, 1), Z(), Z()))
     assert expr1 != expr2, "Error: Expr.__eq__()"
+
+
+# ---- id ----
+def test_id():
+    assert id(Z()) == id(Z()), "id is not equal."
+    assert id(S()) == id(S()), "id is not equal."
+    assert id(P(1, 1)) == id(P(1, 1)), "id is not equal."
+    assert id(C(S(), Z())) == id(C(S(), Z())), "id is not equal."
+    assert id(R(S(), P(2, 1))) == id(R(S(), P(2, 1))), "id is not equal."
+
+
+def test_id_change():
+    ch_expr = C(S(), Z()).change(deque([2]), S())
+    assert id(ch_expr) == id(C(S(), S())), "id is not equal."
 
 
 # ---- str -----
@@ -462,12 +419,3 @@ def test_expr_to_str_rec():
         ["C(S(), Z())", "R(Z(), S())"],
     ]
     assert str_expr == expr_to_str_rec(expr), "Error: {expr} != {str_expr}"
-
-
-# ---- id ----
-def test_id():
-    assert id(Z()) == id(Z()), "id is not equal."
-    assert id(S()) == id(S()), "id is not equal."
-    assert id(P(1, 1)) == id(P(1, 1)), "id is not equal."
-    assert id(C(S(), Z())) == id(C(S(), Z())), "id is not equal."
-    assert id(R(S(), P(2, 1))) == id(R(S(), P(2, 1))), "id is not equal."

--- a/tests/AlphaStrictPrf/test_strict_prf.py
+++ b/tests/AlphaStrictPrf/test_strict_prf.py
@@ -73,13 +73,8 @@ def test_change_complex():
     pos = deque([2, 1])
     new_expr = expr.change(pos, R(Z(), P(2, 1)))
     expected_expr = C(R(Z(), P(2, 1)), C(R(Z(), P(2, 1)), S()))
-    assert new_expr == expected_expr, "Error: Expr.change()"
-    # check non-destructive
-    expr_copy = expr.copy()
-    for pos in expr.positions():
-        expr_copy.change(pos, Z())
-        assert expr_copy == expr, "Error: Expr.change()"
-        assert id(expr_copy) != id(expr), "Error: Expr.change()"
+    assert new_expr is expected_expr, "Error: Expr.change()"
+    assert new_expr is not expr, "Error: Expr.change()"
 
 
 # ---- copy -----
@@ -467,3 +462,12 @@ def test_expr_to_str_rec():
         ["C(S(), Z())", "R(Z(), S())"],
     ]
     assert str_expr == expr_to_str_rec(expr), "Error: {expr} != {str_expr}"
+
+
+# ---- id ----
+def test_id():
+    assert id(Z()) == id(Z()), "id is not equal."
+    assert id(S()) == id(S()), "id is not equal."
+    assert id(P(1, 1)) == id(P(1, 1)), "id is not equal."
+    assert id(C(S(), Z())) == id(C(S(), Z())), "id is not equal."
+    assert id(R(S(), P(2, 1))) == id(R(S(), P(2, 1))), "id is not equal."


### PR DESCRIPTION
# 目的
#112 による。

# 変更点
- __eq__の廃止
- Singleton Patternを考慮した__new__の追加
- 上の変更によるtestメソッドの廃止
- copyの削除