### PR TITLE
OverflowErrorにおけるtracebackを改善

### DIFF
--- a/prfndim/prfndim.py
+++ b/prfndim/prfndim.py
@@ -1,4 +1,28 @@
 import functools
+import logging
+import sys
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+def custom_excepthook(exc_type, exc_value, exc_tb):
+    if exc_type is OverflowError:
+        tb = exc_tb
+        while tb is not None:
+            frame = tb.tb_frame
+            code = frame.f_code
+            local_vars = frame.f_locals
+            if code.co_name in ["eval", "_eval"] and isinstance(
+                local_vars.get("self"), Expr
+            ):
+                logging.info(
+                    f"OverflowError in Expr = {local_vars["self"]}.{code.co_name}"
+                )
+            tb = tb.tb_next
+    sys.__excepthook__(exc_type, exc_value, exc_tb)
+
+
+sys.excepthook = custom_excepthook
 
 LRU_CACHE_SIZE = 1000
 OVERFLOW = 1000

--- a/tests/prfndim/test_prfndim.py
+++ b/tests/prfndim/test_prfndim.py
@@ -299,3 +299,16 @@ def test_r_is_valid():
 
     # termianl function is invalid
     assert not R(P(3, 1), Z(), Z(), Z(), S()).is_valid
+
+
+def test_overflow_trace_back():
+    """
+    Show details of Overflow Error traceback
+    when executed in standard python file
+    """
+    plus = R(P(1, 1), C(S(), P(3, 2)), P(1, 1))
+    mult = R(P(1, 1), C(plus, P(3, 2), P(3, 3)), Z())
+    power = R(P(1, 1), C(mult, P(3, 2), P(3, 3)), C(S(), Z()))
+    tetra = R(P(1, 1), C(power, P(3, 2), P(3, 3)), C(S(), Z()))
+    with pytest.raises(OverflowError):
+        tetra.eval(5, 2)


### PR DESCRIPTION
# 目的

#131 のため、Overflowが起きた際にExpr.eval()の再帰を呼び出し元までさかのぼってエラーログを出す。

# 変更点
- prfndim.pyでsys.excepthookを書き換えた
- test_prfndim.pyでテトレーションによるOverflowの例を追加した