### PR TITLE
eval.ipynbのリファクタリング

### DIFF
--- a/src/models/eval.ipynb
+++ b/src/models/eval.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,31 +24,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/tmp/ipykernel_30910/3843051679.py:2: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.\n",
-      "  state_dict = torch.load(\"/home/takeru/AlphaSymbol/models/model_30000epochs_20241202235904.pth\")\n"
+      "/home/takeru/.pyenv/versions/3.12.7/lib/python3.12/site-packages/torch/nn/modules/transformer.py:379: UserWarning: enable_nested_tensor is True, but self.use_nested_tensor is False because encoder_layer.self_attn.batch_first was not True(use batch_first for better inference performance)\n",
+      "  warnings.warn(\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<sos>\n",
-      "Z\n",
-      ")\n",
-      "<eos>\n"
+      "['<sos>', 'S', ')', ')', '<eos>']\n"
      ]
     }
    ],
    "source": [
-    "config_path = \"/home/takeru/AlphaSymbol/models/config_20241202235904.yaml\"\n",
-    "state_dict = torch.load(\"/home/takeru/AlphaSymbol/models/model_30000epochs_20241202235904.pth\")\n",
+    "config_path = \"/home/takeru/AlphaSymbol/models/config_20241206174837.yaml\"\n",
+    "state_dict = \"/home/takeru/AlphaSymbol/models/model_30000epochs_20241206182634.pth\"\n",
     "\n",
     "with open(config_path, \"r\") as f:\n",
     "    config = yaml.safe_load(f)\n",
@@ -58,13 +55,19 @@
     "src_vocab = config[\"src_vocab\"]\n",
     "tgt_vocab = config[\"tgt_vocab\"]\n",
     "\n",
-    "model = TransformerModel(len(src_vocab), len(tgt_vocab), src_max_len, tgt_max_len)\n",
+    "model = TransformerModel(len(src_vocab), len(tgt_vocab), src_max_len, tgt_max_len,\n",
+    "        d_model=64,\n",
+    "        nhead=4,\n",
+    "        num_encoder_layers=6,\n",
+    "        num_decoder_layers=6,\n",
+    "        dim_feedforward=512,\n",
+    "        dropout=0.1,)\n",
     "model.eval()\n",
     "\n",
     "inputs = [(0,), (1,), (2,), (3,), (4,), (5,), (6,), (7,), (8,), (9,)]\n",
-    "# outputs = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11]\n",
-    "outputs = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]\n",
-    "# outputs = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]\n",
+    "#outputs = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11]\n",
+    "#outputs = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]\n",
+    "#outputs = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]\n",
     "src_str = get_tgt_str(inputs, outputs)\n",
     "src_tensor = torch.tensor([src_vocab[i] for i in src_str])\n",
     "src_tensor = torch.cat([src_tensor, torch.tensor([src_vocab[\"<pad>\"] for _ in range(src_max_len - src_tensor.shape[0])])])\n",
@@ -74,7 +77,7 @@
     "\n",
     "with torch.no_grad():\n",
     "    for i in range(tgt_max_len):\n",
-    "        model.load_state_dict(state_dict)\n",
+    "        model.load_state_dict(torch.load(state_dict, weights_only=True))\n",
     "        model.eval()\n",
     "        pred = model(src_tensor, out_str)\n",
     "        next_c = pred[0, -1, :]\n",
@@ -83,8 +86,7 @@
     "        if max_indices == tgt_vocab[\"<eos>\"]:\n",
     "            break\n",
     "\n",
-    "for id in out_str[0]:\n",
-    "    print(id2token(tgt_vocab, id))"
+    "print([id2token(tgt_vocab, id) for id in out_str[0]])"
    ]
   }
  ],


### PR DESCRIPTION
# 目的

eval.ipynbのおかしなところをいくつか直した

# 変更点
- tokenの出力を見やすくする
- state_dictにはpathをstrで格納する形式にする
- TransformerModelにおいてkeyword変数を明示する