### PR TITLE
推論に LitTransformer を導入する

### DIFF
--- a/src/models/eval.ipynb
+++ b/src/models/eval.ipynb
@@ -26,43 +26,47 @@
    "outputs": [],
    "source": [
     "from train import LitTransformer\n",
+    "from data import TransformerDataset\n",
     "import torch\n",
     "import yaml\n",
-    "from data import get_tgt_str, build_vocab, id2token"
+    "from data import get_tgt_str, build_vocab, id2token\n",
+    "import pandas as pd"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/takeru/.pyenv/versions/3.12.7/lib/python3.12/site-packages/torch/nn/modules/transformer.py:379: UserWarning: enable_nested_tensor is True, but self.use_nested_tensor is False because encoder_layer.self_attn.batch_first was not True(use batch_first for better inference performance)\n",
+      "  warnings.warn(\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['<sos>', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S']\n"
+      "['<sos>', 'R', ',', 'R', ')', ')', 'P', ',', ',', ',', ',', ',', ',', ',', ',', ')', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ')', '(', ')', ')', '(', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', '(', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', '(', ',', ',', ',', ',', '(', ',', ',', ',', '(', '(', ',', '(', '(', '(', '(', '(', '(', '(', '(', '(', '(', '(', ',', ',', '(', ',', ',', ',', '(', ',', ',', '(', ',', ',', ',', '(', ',', ',', '(', ',', ',', ',', '(', ',', ',', '(', ',', ',', ',', '(', ',', ',', '(', ',', ',', '(', ',', '(', ',', ',', '(', ',', ',']\n"
      ]
     }
    ],
    "source": [
-    "config_path = \"/home/takeru/AlphaSymbol/models/config_20241206174837.yaml\"\n",
-    "state_dict = \"/home/takeru/AlphaSymbol/models/model_30000epochs_20241206182634.pth\"\n",
     "\n",
-    "with open(config_path, \"r\") as f:\n",
-    "    config = yaml.safe_load(f)\n",
+    "data_path = \"/home/takeru/AlphaSymbol/data/prfndim/d3-a5-c3-r5.csv\"\n",
+    "df = pd.read_csv(data_path)\n",
+    "dataset = TransformerDataset(df)\n",
+    "src_max_len = dataset.src_max_len\n",
+    "tgt_max_len = dataset.tgt_max_len\n",
+    "src_vocab = dataset.src_vocab\n",
+    "tgt_vocab = dataset.tgt_vocab\n",
     "\n",
-    "src_max_len = config[\"src_max_len\"]\n",
-    "tgt_max_len = config[\"tgt_max_len\"]\n",
-    "src_vocab = config[\"src_vocab\"]\n",
-    "tgt_vocab = config[\"tgt_vocab\"]\n",
-    "\n",
-    "model = LitTransformer(len(src_vocab), len(tgt_vocab), src_max_len, tgt_max_len,\n",
-    "        d_model=64,\n",
-    "        nhead=4,\n",
-    "        num_encoder_layers=6,\n",
-    "        num_decoder_layers=6,\n",
-    "        dim_feedforward=512,\n",
-    "        dropout=0.1,)\n",
+    "model_path = \"/home/takeru/AlphaSymbol/models/version_13/checkpoints/epoch=299-step=117000.ckpt\"\n",
+    "model = LitTransformer.load_from_checkpoint(model_path)\n",
+    "model.eval()\n",
     "\n",
     "inputs = [(0,), (1,), (2,), (3,), (4,), (5,), (6,), (7,), (8,), (9,)]\n",
     "#outputs = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11]\n",
@@ -72,11 +76,12 @@
     "src_tensor = torch.tensor([src_vocab[i] for i in src_str])\n",
     "src_tensor = torch.cat([src_tensor, torch.tensor([src_vocab[\"<pad>\"] for _ in range(src_max_len - src_tensor.shape[0])])])\n",
     "src_tensor = src_tensor.unsqueeze(0)\n",
+    "src_tensor = src_tensor.to(model.device)\n",
+    "\n",
     "out_str = torch.tensor(tgt_vocab[\"<sos>\"]).reshape((1, ))\n",
     "out_str = out_str.unsqueeze(0)\n",
+    "out_str = out_str.to(model.device)\n",
     "\n",
-    "model.load_state_dict(torch.load(state_dict, weights_only=True))\n",
-    "model.eval()\n",
     "\n",
     "with torch.no_grad():\n",
     "    for i in range(tgt_max_len):\n",

--- a/src/models/eval.ipynb
+++ b/src/models/eval.ipynb
@@ -2,18 +2,9 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The autoreload extension is already loaded. To reload it, use:\n",
-      "  %reload_ext autoreload\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%load_ext autoreload\n",
     "%autoreload 2"
@@ -21,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -44,13 +35,6 @@
      "text": [
       "/home/takeru/.pyenv/versions/3.12.7/lib/python3.12/site-packages/torch/nn/modules/transformer.py:379: UserWarning: enable_nested_tensor is True, but self.use_nested_tensor is False because encoder_layer.self_attn.batch_first was not True(use batch_first for better inference performance)\n",
       "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['<sos>', 'R', ',', 'R', ')', ')', 'P', ',', ',', ',', ',', ',', ',', ',', ',', ')', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ')', '(', ')', ')', '(', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', '(', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', ',', '(', ',', ',', ',', ',', '(', ',', ',', ',', '(', '(', ',', '(', '(', '(', '(', '(', '(', '(', '(', '(', '(', '(', ',', ',', '(', ',', ',', ',', '(', ',', ',', '(', ',', ',', ',', '(', ',', ',', '(', ',', ',', ',', '(', ',', ',', '(', ',', ',', ',', '(', ',', ',', '(', ',', ',', '(', ',', '(', ',', ',', '(', ',', ',']\n"
      ]
     }
    ],
@@ -68,10 +52,13 @@
     "model = LitTransformer.load_from_checkpoint(model_path)\n",
     "model.eval()\n",
     "\n",
-    "inputs = [(0,), (1,), (2,), (3,), (4,), (5,), (6,), (7,), (8,), (9,)]\n",
+    "#inputs = [(0,), (1,), (2,), (3,), (4,), (5,), (6,), (7,), (8,), (9,)]\n",
     "#outputs = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11]\n",
     "#outputs = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]\n",
-    "outputs = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]\n",
+    "#outputs = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]\n",
+    "inputs = [(0,), (0,)]\n",
+    "#outputs = [0, 0]\n",
+    "outputs = [1, 1]\n",
     "src_str = get_tgt_str(inputs, outputs)\n",
     "src_tensor = torch.tensor([src_vocab[i] for i in src_str])\n",
     "src_tensor = torch.cat([src_tensor, torch.tensor([src_vocab[\"<pad>\"] for _ in range(src_max_len - src_tensor.shape[0])])])\n",

--- a/src/models/eval.ipynb
+++ b/src/models/eval.ipynb
@@ -2,9 +2,18 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n"
+     ]
+    }
+   ],
    "source": [
     "%load_ext autoreload\n",
     "%autoreload 2"
@@ -12,11 +21,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from models import TransformerModel\n",
+    "from train import LitTransformer\n",
     "import torch\n",
     "import yaml\n",
     "from data import get_tgt_str, build_vocab, id2token"
@@ -24,22 +33,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/takeru/.pyenv/versions/3.12.7/lib/python3.12/site-packages/torch/nn/modules/transformer.py:379: UserWarning: enable_nested_tensor is True, but self.use_nested_tensor is False because encoder_layer.self_attn.batch_first was not True(use batch_first for better inference performance)\n",
-      "  warnings.warn(\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['<sos>', 'S', ')', ')', '<eos>']\n"
+      "['<sos>', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S', 'S']\n"
      ]
     }
    ],
@@ -55,19 +56,18 @@
     "src_vocab = config[\"src_vocab\"]\n",
     "tgt_vocab = config[\"tgt_vocab\"]\n",
     "\n",
-    "model = TransformerModel(len(src_vocab), len(tgt_vocab), src_max_len, tgt_max_len,\n",
+    "model = LitTransformer(len(src_vocab), len(tgt_vocab), src_max_len, tgt_max_len,\n",
     "        d_model=64,\n",
     "        nhead=4,\n",
     "        num_encoder_layers=6,\n",
     "        num_decoder_layers=6,\n",
     "        dim_feedforward=512,\n",
     "        dropout=0.1,)\n",
-    "model.eval()\n",
     "\n",
     "inputs = [(0,), (1,), (2,), (3,), (4,), (5,), (6,), (7,), (8,), (9,)]\n",
     "#outputs = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11]\n",
     "#outputs = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]\n",
-    "#outputs = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]\n",
+    "outputs = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]\n",
     "src_str = get_tgt_str(inputs, outputs)\n",
     "src_tensor = torch.tensor([src_vocab[i] for i in src_str])\n",
     "src_tensor = torch.cat([src_tensor, torch.tensor([src_vocab[\"<pad>\"] for _ in range(src_max_len - src_tensor.shape[0])])])\n",
@@ -75,10 +75,11 @@
     "out_str = torch.tensor(tgt_vocab[\"<sos>\"]).reshape((1, ))\n",
     "out_str = out_str.unsqueeze(0)\n",
     "\n",
+    "model.load_state_dict(torch.load(state_dict, weights_only=True))\n",
+    "model.eval()\n",
+    "\n",
     "with torch.no_grad():\n",
     "    for i in range(tgt_max_len):\n",
-    "        model.load_state_dict(torch.load(state_dict, weights_only=True))\n",
-    "        model.eval()\n",
     "        pred = model(src_tensor, out_str)\n",
     "        next_c = pred[0, -1, :]\n",
     "        max_values, max_indices = torch.max(next_c, axis=0)\n",

--- a/src/models/train.py
+++ b/src/models/train.py
@@ -56,8 +56,13 @@ class LitTransformer(L.LightningModule):
         tgt = tgt.permute(1, 0, 2)  # (T, N, E)
         src = src + self.src_pos_enc(src)
         tgt = tgt + self.tgt_pos_enc(tgt)
-        tgt_mask = nn.Transformer.generate_square_subsequent_mask(tgt.size(0))
-        output = self.transformer(src, tgt, tgt_mask=tgt_mask)
+        if self.training:
+            tgt_mask = nn.Transformer.generate_square_subsequent_mask(
+                tgt.size(0)
+            )
+            output = self.transformer(src, tgt, tgt_mask=tgt_mask)
+        else:
+            output = self.transformer(src, tgt)
         output = self.fc_out(output)  # (T, N, C)
         return output
 
@@ -75,20 +80,21 @@ class LitTransformer(L.LightningModule):
         return optim.Adam(self.parameters(), lr=self.learning_rate)
 
 
-data_path = "/home/takeru/AlphaSymbol/data/prfndim/d3-a2-c3-r3-status.csv"
-models_output_dir = "./temp/"
-config_dir = "./temp/"
-df = pd.read_csv(data_path)
-dataset = TransformerDataset(df)
-dataloadr = utils.data.DataLoader(dataset, batch_size=4, shuffle=True)
+if __name__ == "__main__":
+    data_path = "/home/takeru/AlphaSymbol/data/prfndim/d3-a2-c3-r3-status.csv"
+    models_output_dir = "./temp/"
+    config_dir = "./temp/"
+    df = pd.read_csv(data_path)
+    dataset = TransformerDataset(df)
+    dataloadr = utils.data.DataLoader(dataset, batch_size=4, shuffle=True)
 
-lightning_module = LitTransformer(
-    src_vocab_size=len(dataset.src_vocab),
-    tgt_vocab_size=len(dataset.tgt_vocab),
-    src_max_len=dataset.src_max_len,
-    tgt_max_len=dataset.tgt_max_len,
-    learning_rate=0.0001,
-)
+    lightning_module = LitTransformer(
+        src_vocab_size=len(dataset.src_vocab),
+        tgt_vocab_size=len(dataset.tgt_vocab),
+        src_max_len=dataset.src_max_len,
+        tgt_max_len=dataset.tgt_max_len,
+        learning_rate=0.0001,
+    )
 
-trainer = L.Trainer(max_epochs=100, accelerator="gpu", devices=1)
-trainer.fit(lightning_module, dataloadr)
+    trainer = L.Trainer(max_epochs=100, accelerator="gpu", devices=1)
+    trainer.fit(lightning_module, dataloadr)

--- a/src/models/train.py
+++ b/src/models/train.py
@@ -71,15 +71,6 @@ class LitTransformer(L.LightningModule):
         loss = self.loss_fn(output, tgt_output)
         return loss
 
-    def predict_step(self, batch, batch_idx):
-        src = self.src_embedding(src) * torch.sqrt(
-            torch.tensor(self.d_model, dtype=torch.float32)
-        )
-        tgt = self.tgt_embedding(tgt) * torch.sqrt(
-            torch.tensor(self.d_model, dtype=torch.float32)
-        )
-        self.transformer(src, tgt, src_mask=None, tgt_mask=None)
-
     def configure_optimizers(self):
         return optim.Adam(self.parameters(), lr=self.learning_rate)
 


### PR DESCRIPTION
# 目的
#162 に即して推論のコードでLitTransformerを利用可能にする。

# 変更点
- eval.ipynbにおいて用いるモデルをLitTransformerにした。
- その他推論のバグ修正

# 補足
- 異なる入力値でも同一の出力が出てしまうというエラーに関しては #163 に対処を引き継ぐ