### PR TITLE
Fix bug of pipeline.py. Add header to an output csv file.

### DIFF
--- a/data_script/generate_by_depth.py
+++ b/data_script/generate_by_depth.py
@@ -42,7 +42,7 @@ def save_to_csv(data):
 
     # ファイルが存在しない場合は新規作成、存在する場合は追記
     assert OUTPUT_FILE.exists(), f"Output file is not created: {OUTPUT_FILE}"
-    df.to_csv(OUTPUT_FILE, mode="a", index=False)
+    df.to_csv(OUTPUT_FILE, mode="a", index=False, header=False)
     logging.info(
         "Output file is updated. There are %d exprs", saved_expr_counter
     )
@@ -312,6 +312,8 @@ def generate_by_depth(
         output_file.touch()
 
         OUTPUT_FILE = output_file
+        with open(OUTPUT_FILE, "w") as f:
+            f.write("expr\n")
 
     visited: list[set[bytes]] = [set() for _ in range(max_arity + 1)]
     exprs, _ = _generate_prfndim_by_depth(

--- a/data_script/generate_random.py
+++ b/data_script/generate_random.py
@@ -46,7 +46,7 @@ def save_to_csv(data):
 
     # ファイルが存在しない場合は新規作成、存在する場合は追記
     assert OUTPUT_FILE.exists(), "Output file does not exist"
-    df.to_csv(OUTPUT_FILE, mode="a", index=False)
+    df.to_csv(OUTPUT_FILE, mode="a", index=False, header=False)
 
 
 def output_bytes_not_const(expr: Expr, eq_domain: list[npt.NDArray]) -> bytes:
@@ -170,6 +170,8 @@ def generate_random(
             output_path.unlink()
         output_path.touch()
         OUTPUT_FILE = output_path
+        with open(OUTPUT_FILE, "w") as f:
+            f.write("expr\n")
 
     # gen_exprs[arity]: list of Expr with arity
     # new exprs is generated combining exprs in gen_exprs

--- a/data_script/pipeline.py
+++ b/data_script/pipeline.py
@@ -11,10 +11,11 @@ from data_script.status_columns import status_columns
 
 max_value = 10
 sample_num = 10
+random_choice_num = 10000
 depth = 3
 max_arity = 3
-max_c = 3
-max_r = 3
+max_c = 5
+max_r = 7
 
 
 eq_domain = [np.zeros((sample_num, 1))] + [
@@ -41,7 +42,7 @@ generate_by_depth(
 )
 
 generate_random(
-    sample_num=sample_num,
+    sample_num=random_choice_num,
     max_p_arity=max_arity,
     max_c_args=max_c,
     max_r_args=max_r,


### PR DESCRIPTION
# Purpose

Add "expr" header to the output csv files to solve bug.

# Changes
- Add "expr" header process in generation_by_depth.py
- Add "expr" header process in generate_random.py
- Add random_choice variable to pipeline.py. Actually, this is not suit for this PR.