### PR TITLE
✨ Organize batch along with token length

### DIFF
--- a/src/model_meta/data.py
+++ b/src/model_meta/data.py
@@ -90,7 +90,7 @@ class PREDataModule(pl.LightningDataModule):
         Args:
         - data_path (str): path to the CSV file
         - max_value (int): the maximum value of the input and output
-        - min_n_tokens_in_batch (int): the maximum number of tokens in a batch
+        - min_n_tokens_in_batch (int): the minimum number of tokens in a batch
         - num_workers (int): the number of workers for data loading (used in DataLoader)
         - test_ratio (float): the ratio of (test + val) / (test + val + train)
         - val_ratio (float): the ratio of val / (val + test)

--- a/src/model_meta/train.py
+++ b/src/model_meta/train.py
@@ -179,9 +179,9 @@ def main(cfg: DictConfig):
     with open(f"{log_dir}/data_module.pkl", "wb") as f:
         data_module_for_save = copy.copy(data_module)
         data_module_for_save.df = None  # This attr is too large.
-        data_module_for_save.train_seq = None
-        data_module_for_save.val_seq = None
-        data_module_for_save.test_seq = None
+        data_module_for_save.train_data = None
+        data_module_for_save.val_data = None
+        data_module_for_save.test_data = None
         pickle.dump(data_module_for_save, f)
 
     trainer.fit(model, data_module)

--- a/src/model_meta/train.py
+++ b/src/model_meta/train.py
@@ -141,12 +141,11 @@ def main(cfg: DictConfig):
     log_dir = Path(HydraConfig.get().run.dir)
     data_module = PREDataModule(
         data_path=cfg.data_path,
-        batch_size=cfg.batch_size,
         max_value=cfg.max_value,
         num_workers=cfg.num_workers,
         test_ratio=cfg.test_ratio,
         val_ratio=cfg.val_ratio,
-        max_n_tokens_in_batch=cfg.max_n_tokens_in_batch,
+        min_n_tokens_in_batch=cfg.min_n_tokens_in_batch,
     )
     model = LitTransformer(
         src_token_num=data_module.src_token_num,
@@ -186,12 +185,6 @@ def main(cfg: DictConfig):
         pickle.dump(data_module_for_save, f)
 
     trainer.fit(model, data_module)
-
-
-def show_memory():
-    print(
-        f"{torch.cuda.memory_allocated() / 8 / 1000 / 1000}MB,{torch.cuda.memory_reserved() / 8 / 1000 / 1000} MB"
-    )
 
 
 if __name__ == "__main__":

--- a/src/model_meta/train.py
+++ b/src/model_meta/train.py
@@ -146,6 +146,7 @@ def main(cfg: DictConfig):
         num_workers=cfg.num_workers,
         test_ratio=cfg.test_ratio,
         val_ratio=cfg.val_ratio,
+        max_n_tokens_in_batch=cfg.max_n_tokens_in_batch,
     )
     model = LitTransformer(
         src_token_num=data_module.src_token_num,
@@ -185,6 +186,12 @@ def main(cfg: DictConfig):
         pickle.dump(data_module_for_save, f)
 
     trainer.fit(model, data_module)
+
+
+def show_memory():
+    print(
+        f"{torch.cuda.memory_allocated() / 8 / 1000 / 1000}MB,{torch.cuda.memory_reserved() / 8 / 1000 / 1000} MB"
+    )
 
 
 if __name__ == "__main__":

--- a/src/model_meta/training_config.yaml
+++ b/src/model_meta/training_config.yaml
@@ -3,20 +3,21 @@ hydra:
     dir: "./logs/${now:%Y-%m%d-%H%M-%S}/"
   
 data_path: "/home/takeru/AlphaSymbol/temp/add_in_out_extract1000.csv"
-max_epoch: 10
+max_epoch: 3
 max_value: 2000 # max value occurd in input and output of PRE
-batch_size: 32
+batch_size: 8
+max_n_tokens_in_batch: 1000
 test_ratio: 0.5 # (test + val) / (test + val + train)
 val_ratio: 0.25 # val / (val + test)
 num_workers: 31
 token_embed_dim: 64
-emb_expansion_factor: 2
-learning_rate: "8*10**(-5)"
+emb_expansion_factor: 1
+learning_rate: "10**(-3)"
   
 transformer:
-  nhead: 8
-  num_encoder_layers: 6
-  num_decoder_layers: 6
+  nhead: 16
+  num_encoder_layers: 4
+  num_decoder_layers: 16
   dim_feedforward: 2048
   dropout: 0.1
   

--- a/src/model_meta/training_config.yaml
+++ b/src/model_meta/training_config.yaml
@@ -2,22 +2,21 @@ hydra:
   run:
     dir: "./logs/${now:%Y-%m%d-%H%M-%S}/"
   
-data_path: "/home/takeru/AlphaSymbol/temp/add_in_out_extract1000.csv"
-max_epoch: 3
+data_path: "/home/takeru/AlphaSymbol/temp/add_in_out.csv"
+max_epoch: 500
 max_value: 2000 # max value occurd in input and output of PRE
-batch_size: 8
-max_n_tokens_in_batch: 1000
+min_n_tokens_in_batch: 3000
 test_ratio: 0.5 # (test + val) / (test + val + train)
 val_ratio: 0.25 # val / (val + test)
 num_workers: 31
-token_embed_dim: 64
+token_embed_dim: 16
 emb_expansion_factor: 1
-learning_rate: "10**(-3)"
+learning_rate: "3*10**(-4)"
   
 transformer:
-  nhead: 16
+  nhead: 8
   num_encoder_layers: 4
-  num_decoder_layers: 16
-  dim_feedforward: 2048
+  num_decoder_layers: 6
+  dim_feedforward: 512
   dropout: 0.1
   


### PR DESCRIPTION
# Purpose
#128
Make batches of groups of samples which have the same the number of points so that the number of padding decrease in a batch.

# Changes
- Add collate_fn() and batch_sampler() in data.py
- Add max_n_tokens_batch parameters which defines the size of batch dinamicaly.

# Suppelement
- The parameters of training_config.yaml is the condition that train.py worked.