### PR TITLE
Add skipping complex output in meta evaluation

### DIFF
--- a/meta_sr/evaluation_with_prfndim.py
+++ b/meta_sr/evaluation_with_prfndim.py
@@ -50,7 +50,9 @@ def pred_output(est, xs_reg, ys_reg, xs_test):
     ys_pred = []
     for xs in xs_test:
         dict_vars = {f"x_{i}": x for i, x in enumerate(xs)}
-        ys_pred.append(expr.subs(dict_vars))
+        val = expr.subs(dict_vars)
+        assert val.is_real
+        ys_pred.append(val)
     return ys_pred
 
 


### PR DESCRIPTION
# Purpose
There are some errors in evaluation_with_prfndim.py caused by complex value output of Meta AI SR model.


# Changes
- Assert error when the output is not real number in pred_output()